### PR TITLE
remove chain from vote

### DIFF
--- a/pbf/vote/create.proto
+++ b/pbf/vote/create.proto
@@ -9,7 +9,6 @@ option go_package = "./;vote";
 //         "object": [
 //             {
 //                 "public": {
-//                     "chain": "421614",
 //                     "claim": "778237",
 //                     "kind": "stake",
 //                     "lifecycle": "onchain",
@@ -35,18 +34,16 @@ message CreateI_Object {
 message CreateI_Object_Intern {}
 
 message CreateI_Object_Public {
-  // chain is the chain ID on which a vote got expressed.
-  string chain = 100;
   // claim is the ID of the referenced claim being voted on. Note that the
   // lifecycle of the referenced claim must be compliant with the vote kind
   // provided.
-  string claim = 200;
+  string claim = 100;
   // hash is a votes's confirmed onchain transaction hash. hash left empty
   // implies an interim lifecycle phase "pending". Setting hash implies that the
   // given vote got confirmed onchain, and with it the vote's interim lifecycle
   // phase will not be "pending" anymore, but instead switch to the provided
   // desired lifecycle phase.
-  string hash = 300;
+  string hash = 200;
   // kind is the type of vote, e.g. "stake" or "truth" on which a vote is cast.
   // Note that kind must be compliant with the lifecycle of the referenced
   // claim.
@@ -59,7 +56,7 @@ message CreateI_Object_Public {
   //     have set kind "stake" to verify real events on claims of kind
   //     "resolve".
   //
-  string kind = 400;
+  string kind = 300;
   // lifecycle describes the vote's status within the system. This field may
   // look like one of the examples below.
   //
@@ -73,16 +70,16 @@ message CreateI_Object_Public {
   //
   //     "onchain" describes votes that have been confirmed onchain
   //
-  string lifecycle = 500;
+  string lifecycle = 400;
   // meta may contain onchain arbitrary meta data.
-  string meta = 600;
+  string meta = 500;
   // option is the side of the vote being cast, e.g. "true" or "false". If
   // option is "true", then the vote is in agreement. If option is "false", then
   // the vote is in disagreement.
-  string option = 700;
+  string option = 600;
   // value is the weight of the vote being cast. If kind is "stake", then value
   // might be any positive number. If kind is "truth", then value must be 1.
-  string value = 800;
+  string value = 700;
 }
 
 // CreateO is the output for creating votes.

--- a/pbf/vote/search.proto
+++ b/pbf/vote/search.proto
@@ -77,7 +77,6 @@ message SearchI_Object_Symbol {}
 //                     "owner": "551265"
 //                 },
 //                 "public": {
-//                     "chain": "421614",
 //                     "claim": "778237",
 //                     "hash": "0x1234",
 //                     "kind": "stake",
@@ -114,16 +113,14 @@ message SearchO_Object_Intern {
 }
 
 message SearchO_Object_Public {
-  // chain is the chain ID on which a vote got expressed.
-  string chain = 100;
   // claim is the ID of the referenced claim being voted on. Note that the
   // lifecycle of the referenced claim must be compliant with the vote kind
   // provided.
-  string claim = 200;
+  string claim = 100;
   // hash is the onchain transaction hash for this vote. Setting hash implies
   // that the vote got confirmed onchain, and with it the lifecycle phase
   // "onchain" will be inferred automatically.
-  string hash = 300;
+  string hash = 200;
   // kind is the type of vote, e.g. "stake" or "truth" on which a vote is cast.
   // Note that kind must be compliant with the lifecycle of the referenced
   // claim.
@@ -136,7 +133,7 @@ message SearchO_Object_Public {
   //     have set kind "stake" to verify real events on claims of kind
   //     "resolve".
   //
-  string kind = 400;
+  string kind = 300;
   // lifecycle describes the vote's status within the system. This field may
   // look like one of the examples below.
   //
@@ -150,14 +147,14 @@ message SearchO_Object_Public {
   //
   //     "onchain" describes votes that have been confirmed onchain
   //
-  string lifecycle = 500;
+  string lifecycle = 400;
   // meta may contain onchain arbitrary meta data.
-  string meta = 600;
+  string meta = 500;
   // option is the side of the vote being cast, e.g. "true" or "false". If
   // option is "true", then the vote is in agreement. If option is "false", then
   // the vote is in disagreement.
-  string option = 700;
+  string option = 600;
   // value is the weight of the vote being cast. If kind is "stake", then value
   // might be any positive number. If kind is "truth", then value must be 1.
-  string value = 800;
+  string value = 700;
 }

--- a/pbf/wallet/search.proto
+++ b/pbf/wallet/search.proto
@@ -4,7 +4,7 @@ package wallet;
 option go_package = "./;wallet";
 
 // SearchI is the input for searching wallets. Note that searching for wallets
-// is restricted to the respective authenticated users. In order words, wallets
+// is restricted to the respective authenticated users. In other words, wallets
 // are not available to the public, and only the wallet owner can search their
 // own wallets.
 //


### PR DESCRIPTION
We can remove the redundant chain information from the vote resources, because votes reference claims, and claim resources have the chain information already.